### PR TITLE
bugfix for gpcheckcat when issue `gpcheckcat -C pg_class`

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1258,7 +1258,7 @@ def checkTableACL(cat):
     try:
         conn = connect2(GV.cfg[GV.coordinator_dbid], utilityMode=False)
         with conn.cursor() as curs:
-            curs = db.execute(qry)
+            curs.execute(qry)
             nrows = curs.rowcount
 
             if nrows == 0:


### PR DESCRIPTION
Error occurs when issue command `gpcheckcat -C pg_class`. The output is "[ERROR] executing: Cross consistency check for pg_class\n  Execution error: name 'db' is not defined".
After read the code, it was just a small bug in the gpcheckcat, and I fix it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
